### PR TITLE
feat: Filament v4 header nav, RTL chevrons, route-key URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `getRecordNavigationHeaderActions()` for **Filament v4** (header actions are not passed through `configureAction()`).
+- Config: `rtl_locales`, `url_route`, `previous_tooltip_key`, `next_tooltip_key`.
+- `getRecordNavigationUrlRoute()` hook for edit vs view pages.
+- Record URLs use `getRouteKey()` (UUID / custom route keys) while `order_column` still drives adjacency (e.g. `id`).
+
+### Changed
+
+- `configureAction()` fall back: call `parent::configureAction()` only when the method exists (Filament v4 compatibility).
+- `getAdjacentRecord()` uses `getAttribute($orderColumn)` and skips when value is null.
+- `composer.json`: require `filament/filament` `^3.2 | ^4.0`.
+
 ## [v1.0.0] - 2025-05-27
 ### Added
 - `NextRecordAction` Filament action

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A Laravel package that adds elegant next/previous record navigation to your Fila
 
 ## Requirements
 
-- PHP ^8.1
-- Laravel ^10.0
-- Filament ^3.0
+- PHP ^8.2
+- Laravel ^10.0 / ^11.0 / ^12.0 (typical with Filament)
+- Filament **^3.2** or **^4.0**
 
 ## Demo
 ![Package Demo](example.gif)
@@ -65,7 +65,19 @@ class ViewPost extends ViewRecord
 
 ### 2. Add navigation actions to your page
 
-Add the navigation actions to your page's action array:
+**Filament v4:** header actions are not configured via `configureAction()`. Return the pre-wired actions from the trait:
+
+```php
+protected function getHeaderActions(): array
+{
+    return [
+        ...$this->getRecordNavigationHeaderActions(),
+        // ... your other actions
+    ];
+}
+```
+
+**Filament v3** (or if you customize actions in `configureAction()`): register the actions as before:
 
 ```php
 <?php
@@ -99,6 +111,10 @@ class ViewPost extends ViewRecord
 
 That's it! Your Filament resource pages now have beautiful next/previous navigation buttons.
 
+**RTL panels:** set `rtl_locales` in config (e.g. `ar`, `ckb`). Chevron icons swap so “previous / next” match reading direction.
+
+**UUID route keys:** keep `order_column` as `id` (or another sortable column). URLs use `getRouteKey()` automatically.
+
 ## Configuration
 
 The package comes with sensible defaults, but you can customize the behavior by publishing and modifying the configuration file:
@@ -128,6 +144,23 @@ return [
     */
     'previous_direction' => 'desc',
     'next_direction' => 'asc',
+
+    /*
+    | Locales that use RTL — previous/next chevrons are mirrored.
+    */
+    'rtl_locales' => ['ar', 'ckb', 'he', 'fa', 'ur'],
+
+    /*
+    | Default route passed to Resource::getUrl() — 'view' or 'edit'.
+    | Override per page via getRecordNavigationUrlRoute().
+    */
+    'url_route' => 'view',
+
+    /*
+    | Optional translation keys for tooltips (passed to __()).
+    */
+    'previous_tooltip_key' => null,
+    'next_tooltip_key' => null,
 ];
 ```
 
@@ -179,32 +212,16 @@ class ViewPost extends ViewRecord
 ```
 ### Custom Record URLs
 
-By default, the navigation uses the `view` route. You can customize this:
+By default, the navigation uses the `view` route (`config('filament-record-nav.url_route')`). For edit-only resources, override the route name (URLs still use `getRouteKey()`):
 
 ```php
-<?php
-
-namespace App\Filament\Resources\PostResource\Pages;
-
-use App\Filament\Resources\PostResource;
-use Filament\Actions;
-use Filament\Resources\Pages\EditRecord;
-
-use Illuminate\Database\Eloquent\Model; 
-use Nben\FilamentRecordNav\Concerns\WithRecordNavigation;
-
-class EditPost extends EditRecord
+protected function getRecordNavigationUrlRoute(): string
 {
-    use WithRecordNavigation;
-
-    protected static string $resource = PostResource::class;
-
-    protected function getRecordUrl(Model $record): string
-    {
-        return static::getResource()::getUrl('edit', ['record' => $record]);
-    }
+    return 'edit';
 }
 ```
+
+You can still override `getRecordUrl()` entirely if you need custom parameters.
 
 ### Customizing Action Appearance
 

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,13 @@
     },
     "suggest": {
         "filament/spatie-laravel-media-library-plugin": "For enhanced media management in your resources",
-        "filament/spatie-laravel-settings-plugin": "For application settings management", 
+        "filament/spatie-laravel-settings-plugin": "For application settings management",
         "spatie/laravel-activitylog": "For tracking record changes and navigation history",
         "spatie/laravel-permission": "For role-based access control in your admin panel"
     },
     "require": {
-        "php": "^8.2"
-    },
-    "require-dev": {
-        "filament/filament": "^3.2"
+        "php": "^8.2",
+        "filament/filament": "^3.2 | ^4.0"
     },
     "license": "MIT",
     "autoload": {
@@ -27,7 +25,6 @@
             "Nben\\FilamentRecordNav\\": "src/"
         }
     },
-    
     "extra": {
         "laravel": {
             "providers": [

--- a/config/filament-record-nav.php
+++ b/config/filament-record-nav.php
@@ -3,16 +3,49 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Default Navigation Column
+    | Order column
     |--------------------------------------------------------------------------
+    |
+    | Column used to find adjacent records. Use a numeric or chronological
+    | column (e.g. id, sort_order). If your model uses UUID in the URL but
+    | integer id in the database, keep this as id — URLs still use getRouteKey().
+    |
     */
     'order_column' => 'id',
 
     /*
     |--------------------------------------------------------------------------
-    | Navigation Directions
+    | Adjacent record query direction
     |--------------------------------------------------------------------------
     */
     'previous_direction' => 'desc',
     'next_direction' => 'asc',
+
+    /*
+    |--------------------------------------------------------------------------
+    | RTL locales (swap prev/next chevrons so “back” points visually correct)
+    |--------------------------------------------------------------------------
+    */
+    'rtl_locales' => ['ar', 'ckb', 'he', 'fa', 'ur'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Filament route name for getUrl() (view | edit)
+    |--------------------------------------------------------------------------
+    |
+    | Override per page with getRecordNavigationUrlRoute() when needed.
+    |
+    */
+    'url_route' => 'view',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tooltip translation keys (optional)
+    |--------------------------------------------------------------------------
+    |
+    | When set, __() is used so you can use models.previous_record etc.
+    |
+    */
+    'previous_tooltip_key' => null,
+    'next_tooltip_key' => null,
 ];

--- a/src/Actions/NextRecordAction.php
+++ b/src/Actions/NextRecordAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Nben\FilamentRecordNav\Actions;
 
 use Filament\Actions\Action;
@@ -14,7 +16,7 @@ class NextRecordAction extends Action
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         $this->hiddenLabel()
             ->outlined()
             ->icon('heroicon-o-chevron-right')

--- a/src/Actions/PreviousRecordAction.php
+++ b/src/Actions/PreviousRecordAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Nben\FilamentRecordNav\Actions;
 
 use Filament\Actions\Action;
@@ -14,7 +16,7 @@ class PreviousRecordAction extends Action
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         $this->hiddenLabel()
             ->outlined()
             ->icon('heroicon-o-chevron-left')

--- a/src/Concerns/WithRecordNavigation.php
+++ b/src/Concerns/WithRecordNavigation.php
@@ -1,49 +1,125 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Nben\FilamentRecordNav\Concerns;
 
+use Filament\Actions\Action;
+use Illuminate\Database\Eloquent\Model;
 use Nben\FilamentRecordNav\Actions\NextRecordAction;
 use Nben\FilamentRecordNav\Actions\PreviousRecordAction;
-use Filament\Actions\Action;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 
 trait WithRecordNavigation
 {
+    /**
+     * Filament v4: header actions are not passed through configureAction().
+     * Merge this into getHeaderActions(), e.g. return $this->getRecordNavigationHeaderActions();
+     *
+     * @return array<int, PreviousRecordAction|NextRecordAction>
+     */
+    protected function getRecordNavigationHeaderActions(): array
+    {
+        $previous = $this->getPreviousRecord();
+        $next = $this->getNextRecord();
+        $rtl = $this->recordNavigationIsRtl();
+
+        return [
+            PreviousRecordAction::make()
+                ->tooltip($this->getPreviousRecordTooltip())
+                ->icon($rtl ? 'heroicon-o-chevron-right' : 'heroicon-o-chevron-left')
+                ->color($previous ? 'primary' : 'gray')
+                ->disabled(! $previous)
+                ->url($previous ? $this->getRecordUrl($previous) : null),
+            NextRecordAction::make()
+                ->tooltip($this->getNextRecordTooltip())
+                ->icon($rtl ? 'heroicon-o-chevron-left' : 'heroicon-o-chevron-right')
+                ->color($next ? 'primary' : 'gray')
+                ->disabled(! $next)
+                ->url($next ? $this->getRecordUrl($next) : null),
+        ];
+    }
+
+    protected function getPreviousRecordTooltip(): string
+    {
+        $key = config('filament-record-nav.previous_tooltip_key');
+
+        return $key ? __($key) : __('Previous record');
+    }
+
+    protected function getNextRecordTooltip(): string
+    {
+        $key = config('filament-record-nav.next_tooltip_key');
+
+        return $key ? __($key) : __('Next record');
+    }
+
+    protected function recordNavigationIsRtl(): bool
+    {
+        $locales = config('filament-record-nav.rtl_locales', ['ar', 'ckb', 'he', 'fa', 'ur']);
+
+        return in_array(app()->getLocale(), $locales, true);
+    }
+
+    /**
+     * Filament v3 / legacy — not used for header actions in Filament v4.
+     */
     protected function configureAction(Action $action): void
     {
         match (true) {
             $action instanceof PreviousRecordAction => $this->configurePreviousAction($action),
             $action instanceof NextRecordAction => $this->configureNextAction($action),
-            default => parent::configureAction($action),
+            default => $this->invokeParentConfigureAction($action),
         };
+    }
+
+    protected function invokeParentConfigureAction(Action $action): void
+    {
+        if (method_exists(parent::class, 'configureAction')) {
+            parent::configureAction($action);
+        }
     }
 
     protected function configurePreviousAction(Action $action): void
     {
         $previous = $this->getPreviousRecord();
-        
-        $action->tooltip('Previous record')
-            ->icon('heroicon-o-chevron-left')
+        $rtl = $this->recordNavigationIsRtl();
+
+        $action->tooltip($this->getPreviousRecordTooltip())
+            ->icon($rtl ? 'heroicon-o-chevron-right' : 'heroicon-o-chevron-left')
             ->color($previous ? 'primary' : 'gray')
-            ->disabled(!$previous)
+            ->disabled(! $previous)
             ->url($previous ? $this->getRecordUrl($previous) : null);
     }
 
     protected function configureNextAction(Action $action): void
     {
         $next = $this->getNextRecord();
-        
-        $action->tooltip('Next record')
-            ->icon('heroicon-o-chevron-right')
+        $rtl = $this->recordNavigationIsRtl();
+
+        $action->tooltip($this->getNextRecordTooltip())
+            ->icon($rtl ? 'heroicon-o-chevron-left' : 'heroicon-o-chevron-right')
             ->color($next ? 'primary' : 'gray')
-            ->disabled(!$next)
+            ->disabled(! $next)
             ->url($next ? $this->getRecordUrl($next) : null);
     }
 
+    /**
+     * Uses the model’s route key (UUID, slug, etc.) for the URL parameter.
+     */
     protected function getRecordUrl(Model $record): string
     {
-        return static::getResource()::getUrl('view', ['record' => $record]);
+        return static::getResource()::getUrl(
+            $this->getRecordNavigationUrlRoute(),
+            ['record' => $record->getRouteKey()],
+        );
+    }
+
+    /**
+     * @return 'view'|'edit'|string
+     */
+    protected function getRecordNavigationUrlRoute(): string
+    {
+        return config('filament-record-nav.url_route', 'view');
     }
 
     protected function getPreviousRecord(): ?Model
@@ -62,9 +138,15 @@ trait WithRecordNavigation
         $orderDirection = config("filament-record-nav.{$direction}_direction", $direction === 'previous' ? 'desc' : 'asc');
         $operator = $direction === 'previous' ? '<' : '>';
 
-        return $this->getRecord()
-            ->newQuery()
-            ->where($orderColumn, $operator, $this->getRecord()->{$orderColumn})
+        $record = $this->getRecord();
+        $currentOrderValue = $record->getAttribute($orderColumn);
+
+        if ($currentOrderValue === null) {
+            return null;
+        }
+
+        return $record->newQuery()
+            ->where($orderColumn, $operator, $currentOrderValue)
             ->orderBy($orderColumn, $orderDirection)
             ->first();
     }

--- a/src/FilamentRecordNavServiceProvider.php
+++ b/src/FilamentRecordNavServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Nben\FilamentRecordNav;
 
 use Illuminate\Support\ServiceProvider;
@@ -18,7 +20,7 @@ class FilamentRecordNavServiceProvider extends ServiceProvider
     public function register(): void
     {
         $configPath = __DIR__.'/../config/filament-record-nav.php';
-        
+
         if (file_exists($configPath)) {
             $this->mergeConfigFrom($configPath, 'filament-record-nav');
         }


### PR DESCRIPTION
- Add getRecordNavigationHeaderActions() for Filament v4 (configureAction not used for header actions)
- Config: rtl_locales, url_route, optional tooltip translation keys
- getRecordUrl uses getRouteKey(); adjacency uses order_column + getAttribute
- Guard parent::configureAction when missing
- Require filament/filament ^3.2 | ^4.0
- Docs: README + CHANGELOG
