### PR TITLE
update defaultAdjacentQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v2.1.1] - 2026-06-03
+
+some improvements and updates, No changes are required to existing code.
+
+### Updated
+- Use resource eloquent query ```getEloquentQuery()```, so the scopes that applied to the resource are applied into the next, previous record.
+
 ## [v2.1.0] - 2026-04-13
 
 A backward-compatible feature release. No changes are required to existing code.

--- a/src/Actions/Concerns/ResolvesAdjacentRecord.php
+++ b/src/Actions/Concerns/ResolvesAdjacentRecord.php
@@ -141,8 +141,11 @@ trait ResolvesAdjacentRecord
         // '<' for previous (records with a lower value), '>' for next.
         $operator = $direction === 'previous' ? '<' : '>';
 
-        return $record
-            ->newQuery()
+        $query = method_exists($livewire, 'getResource')
+            ? $livewire::getResource()::getEloquentQuery()
+            : $this->getRecord()->newQuery();
+
+        return $query
             ->where($orderColumn, $operator, $record->{$orderColumn})
             ->orderBy($orderColumn, $orderDirection)
             ->first();

--- a/src/Concerns/WithRecordNavigation.php
+++ b/src/Concerns/WithRecordNavigation.php
@@ -176,8 +176,11 @@ trait WithRecordNavigation
         // '<' finds records before the current one, '>' finds records after.
         $operator = $direction === 'previous' ? '<' : '>';
 
-        return $this->getRecord()
-            ->newQuery()
+        $query = method_exists(static::class, 'getResource')
+            ? static::getResource()::getEloquentQuery()
+            : $this->getRecord()->newQuery();
+
+        return $query
             ->where($orderColumn, $operator, $this->getRecord()->{$orderColumn})
             ->orderBy($orderColumn, $orderDirection)
             ->first();


### PR DESCRIPTION
update defaultAdjacentQuery in the ResolvesAdjacentRecord trait and WithRecordNavigation trait, if the page has getResource method it will get the EloquentQuery this will solve an issue when there are scopes applied to the resource page that may cause 404 or 403, this update will not effect current working codes, 